### PR TITLE
Rename sandbox.conf(5) x-ref to sandboxctl.conf(5)

### DIFF
--- a/pkg_comp.conf.5
+++ b/pkg_comp.conf.5
@@ -251,5 +251,5 @@ Function executed right after all source trees have been updated by the
 command.
 .El
 .Sh SEE ALSO
-.Xr sandbox.conf 5 ,
+.Xr sandboxctl.conf 5 ,
 .Xr pkg_comp 8


### PR DESCRIPTION
There is no sandbox.conf(5) man page, but there is a sandboxctl.conf(5), so reference that instead.