### PR TITLE
Add hook support for post_build_hook routine

### DIFF
--- a/pkg_comp.conf.5
+++ b/pkg_comp.conf.5
@@ -245,6 +245,10 @@ In other words, they are run under a shell configured with
 .Pp
 The following hooks can be defined:
 .Bl -tag -width post_build_hookXX
+.It Fn post_build_hook
+Function executed right after the set of packages have been built by the
+.Sq build
+command.
 .It Fn post_fetch_hook
 Function executed right after all source trees have been updated by the
 .Sq fetch

--- a/pkg_comp.sh
+++ b/pkg_comp.sh
@@ -78,6 +78,7 @@ pkg_comp_set_defaults() {
     shtk_config_set UPDATE_SOURCES "true"
     shtk_config_set VARBASE "/var"
 
+    post_build_hook() { true; }
     post_fetch_hook() { true; }
 }
 
@@ -500,6 +501,8 @@ pkg_comp_build() {
     run_sandboxctl run /pkg_comp/pbulk/bin/bulkbuild || \
         shtk_cli_error "bulkbuild failed; see ${root}/pkg_comp/work/bulklog/" \
             "for possible details"
+
+    shtk_config_run_hook post_build_hook
 }
 
 


### PR DESCRIPTION
Add hook support for a `post_build_hook` routine that is executed right after packages have been built by the pkg_comp `build` subcommand.

This enables me to, for example, define a `post_build_hook` function in `/usr/local/etc/pkg_comp/default.conf` to preserve the pbulk log outside of the sandbox after the build finishes but before the sandbox gets destroyed:

```
post_build_hook() {
  local logdir bulklog sandbox_bulklog
  logdir=/var/pkg_comp/log
  bulklog=$logdir/bulklog
  sandbox_bulklog=/var/pkg_comp/sandbox/pkg_comp/work/bulklog
  [ ! -e "$sandbox_bulklog" ] && return
  if [ -e "$bulklog" ]; then
    rm -rf "$bulklog.old"
    mv "$bulklog" "$bulklog.old"
  fi
  mkdir -p "$logdir"
  cp -rp "$sandbox_bulklog" "$bulklog"
}
```