### PR TITLE
Change default Git repo from jsonn to NetBSD

### DIFF
--- a/default.conf.in
+++ b/default.conf.in
@@ -11,7 +11,7 @@ SANDBOX_CONFFILE="__PKG_COMP_ETCDIR__/sandbox.conf"
 #FETCH_VCS=cvs
 #CVS_ROOT=:ext:anoncvs@anoncvs.NetBSD.org:/cvsroot
 #CVS_TAG=pkgsrc-2017Q1
-#GIT_URL=https://github.com/jsonn/pkgsrc.git
+#GIT_URL=https://github.com/NetBSD/pkgsrc.git
 #GIT_BRANCH=trunk
 
 # Host file layout.  These directories point to trees managed outside of

--- a/pkg_comp.conf.5
+++ b/pkg_comp.conf.5
@@ -133,7 +133,7 @@ is set to
 .Sq git .
 .Pp
 Default:
-.Sq https://github.com/jsonn/pkgsrc.git .
+.Sq https://github.com/NetBSD/pkgsrc.git .
 .El
 .Pp
 The following variables configure the pkgsrc environment on the host (i.e

--- a/pkg_comp.sh
+++ b/pkg_comp.sh
@@ -67,7 +67,7 @@ pkg_comp_set_defaults() {
     shtk_config_set DISTDIR "/usr/pkgsrc/distfiles"
     shtk_config_set FETCH_VCS "cvs"
     shtk_config_set GIT_BRANCH "trunk"
-    shtk_config_set GIT_URL "https://github.com/jsonn/pkgsrc.git"
+    shtk_config_set GIT_URL "https://github.com/NetBSD/pkgsrc.git"
     shtk_config_set LOCALBASE "/usr/pkg"
     shtk_config_set NJOBS "$(shtk_hw_ncpus)"
     shtk_config_set PACKAGES "/usr/pkgsrc/packages"

--- a/pkg_comp_test.sh
+++ b/pkg_comp_test.sh
@@ -134,7 +134,7 @@ DISTDIR = /usr/pkgsrc/distfiles
 EXTRA_MKCONF is undefined
 FETCH_VCS = cvs
 GIT_BRANCH = trunk
-GIT_URL = https://github.com/jsonn/pkgsrc.git
+GIT_URL = https://github.com/NetBSD/pkgsrc.git
 LOCALBASE = /usr/pkg
 NJOBS = 99
 PACKAGES = /usr/pkgsrc/packages
@@ -218,7 +218,7 @@ DISTDIR = /usr/pkgsrc/distfiles
 EXTRA_MKCONF is undefined
 FETCH_VCS = cvs
 GIT_BRANCH = trunk
-GIT_URL = https://github.com/jsonn/pkgsrc.git
+GIT_URL = https://github.com/NetBSD/pkgsrc.git
 LOCALBASE = /usr/pkg
 NJOBS = 80
 PACKAGES = /usr/pkgsrc/packages


### PR DESCRIPTION
Change the default pkgsrc Git repository from:

  https://github.com/jsonn/pkgsrc.git

to:

  https://github.com/NetBSD/pkgsrc.git

because the pkgsrc Git mirror has moved there according to:

  https://mail-index.netbsd.org/tech-repository/2017/06/10/msg000637.html