### PR TITLE
Avoid mkdir /etc/rc.d when installing pbulk tools

### DIFF
--- a/pkg_comp.sh
+++ b/pkg_comp.sh
@@ -340,6 +340,10 @@ bootstrap_pbulk() {
         "/pkg_comp/pbulk/var" || exit
 
     cat >>"${root}/pkg_comp/pbulk.mk.conf" <<EOF
+# Set the location of system start-up scripts to be under our own pbulk tree
+# to avoid any attempts to create /etc/rc.d (e.g., for rsyncd, even though the
+# script won't be installed) which may be on a read-only file system.
+RCD_SCRIPTS_DIR=/pkg_comp/pbulk/etc/rc.d
 # Be permissive of warnings raised during the build of our own infrastructure.
 # Linux is especially picky and it's easy to trip over different warnings on
 # different platforms.  We just don't want to abort the bootstrapping process


### PR DESCRIPTION
When installing the pbulk tools, rsync is installed, and even though
the rsyncd system start-up script is not installed, the pkgsrc package
install logic tries to create /etc/rc.d, and on macOS Sierra, this
results in a mkdir error message like the following:

```
  # pkg_comp bootstrap
  ...
  ===> Binary install for pbulk-0.65
  => Installing pbulk-0.65 from /pkg_comp/packages/pbulk/All
  mkdir: /etc/rc.d: Read-only file system
```

Avoid the `mkdir /etc/rc.d` attempt by setting RCD_SCRIPTS_DIR to a path
under the pbulk tree which is writable, so no error message is emitted.