### PR TITLE
Don't find pkgsrc bash. It won't be in the sandbox.

### DIFF
--- a/pkg_comp.sh
+++ b/pkg_comp.sh
@@ -181,7 +181,8 @@ setup_bootstrap() {
         local dash_echo_test="$("${bootstrap_sh}" -c 'echo "\\100"')"
         if [ "$(uname -s)" != GNUkFreeBSD -a "${dash_echo_test}" = @ ]; then
             local bash
-            bash="$(which bash)"
+            # Avoid finding pkgsrc-installed bash, as it won't be in the sandbox
+            bash="$(PATH="$(echo ${PATH} | tr ':' '\n' | grep -v '^@PREFIX@/' | tr '\n' ':')" which bash)"
             if [ ${?} -eq 0 ]; then
                 bootstrap_sh="${bash}"
             else


### PR DESCRIPTION
This isn't mergeable as is, so don't worry that I don't have a signed contributor agreement. :-) But it's probably close enough for you to commit something that solves the problem.

The problem: on a platform where `/bin/sh` doesn't suffice for pkgsrc bootstrap and `pkg_comp` tries to find a `bash`, it's possible-to-likely that the host system has all of these properties:

1. pkgsrc has been bootstrapped (presumably that's how we got `pkgtools/pkg_comp` installed)
2. pkgsrc paths are early in `$PATH`, so that pkgsrc tools are found before system-provided ones
3. `shells/bash` has been installed

In such cases, `pkg_comp` currently detects and chooses e.g. `/usr/pkg/bin/bash` as `${bootstrap_sh}`. At some point early in the bootstrap, some build or other fails (one of the `libnbcompat` I think) because it's trying to run `/usr/pkg/bin/bash`, which is not available in the sandbox.

My change is a portion of what I'll commit to pkgsrc shortly (unless you recommend I don't): it removes pkgsrc paths from the `$PATH` that's in effect for `which bash`, so only a non-pkgsrc `bash` will be found. I've tested that this (in conjunction with the obvious `SUBST`) fixes the bootstrap on such platforms.